### PR TITLE
Atualiza endereço da lista do FEMUG-PE

### DIFF
--- a/LISTA.md
+++ b/LISTA.md
@@ -152,7 +152,7 @@ Moderadores   : Nanderson Castro
 -----
 ## FEMUG-PE
 ```
-Lista         : https://groups.google.com/forum/#!forum/femug-pe
+Lista         : http://meetup.com/FEMUG-PE/
 Form Anfitrião: https://bit.ly/FEMUG-PE-ANF
 Capítulo      : Estadual
 Sede          : Recife, PE

--- a/femug-list.json
+++ b/femug-list.json
@@ -147,7 +147,7 @@
     "FEMUG-PE": [{
       "capitulo": "estadual",
       "sede": "Recife, PE",
-      "url": "https://groups.google.com/forum/#!forum/femug-pe",
+      "url": "http://meetup.com/FEMUG-PE/",
       "formulario-anfitriao": "",
       "fundador": "Joselito Júnior",
       "moderadores": [


### PR DESCRIPTION
Passamos a utilizar o Meetup para a organização dos eventos em nosso FEMUG

@danielfilho me informe se é necessária fazer mais alguma atualização para "pe.femug.com" redirecionar para o endereço da lista